### PR TITLE
Fix for SSL EOF errors

### DIFF
--- a/chronos/db.py
+++ b/chronos/db.py
@@ -7,7 +7,7 @@ from chronos.utils import settings
 
 def get_engine():
     dsn_settings = settings.test_pg_dsn if settings.testing else settings.pg_dsn
-    return create_engine(dsn_settings, echo=settings.dev_mode)
+    return create_engine(dsn_settings, echo=settings.dev_mode, pool_pre_ping=True, pool_recycle=3600)
 
 
 engine = get_engine()


### PR DESCRIPTION
* Recycles the pool of connections every hour now by setting `pool_recycle` to 3600 seconds
* Set `pool_pre_ping` to True so that we test a connections liveness upon each checkout
* When we create a new worker, we call engine.dispose() to close all existing database connections otherwise inherit the ones from the parent worker process. This forces the worker to open it's own connections.

#### Screenshots:
Showing the worker_process_init.connect is called (the logger msg is displayed):
<img width="916" height="84" alt="image" src="https://github.com/user-attachments/assets/f390f3aa-ac3a-49ae-a4ad-fd2c5f817703" />

Showing the webhooks still send and work:
<img width="1247" height="933" alt="image" src="https://github.com/user-attachments/assets/23f1a54c-19e5-4276-a6e9-f64055905d2a" />
<img width="449" height="347" alt="image" src="https://github.com/user-attachments/assets/c8239681-f8dc-4b35-8d5c-a4506e0e715b" />

