### PR TITLE
feat: stdlib logging to Logfire; Sentry for warning/error

### DIFF
--- a/chronos/logging.py
+++ b/chronos/logging.py
@@ -1,29 +1,45 @@
+import logging.config
+
 from chronos.utils import settings
 
 logging_level = settings.log_level
 
-config = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'default': {
-            'defaults': 'uvicorn.logging.DefaultFormatter',
-            'fmt': '%(levelprefix)s %(message)s',
-            'use_colors': None,
-        },
-        'access': {
-            'defaults': 'uvicorn.logging.AccessFormatter',
-            'fmt': "%(levelprefix)s %(client_addr)s - '%(request_line)s' %(status_code)s",  # noqa: E501
-        },
-    },
-    'handlers': {
+
+def _logging_dict_config():
+    handlers = {
         'default': {'formatter': 'default', 'class': 'logging.StreamHandler', 'stream': 'ext://sys.stderr'},
         'access': {'formatter': 'access', 'class': 'logging.StreamHandler', 'stream': 'ext://sys.stdout'},
-    },
-    'loggers': {
-        'chronos': {'handlers': ['default'], 'level': logging_level, 'propagate': False},
-        'uvicorn': {'handlers': ['default'], 'level': logging_level, 'propagate': False},
-        'uvicorn.error': {'level': logging_level},
-        'uvicorn.access': {'handlers': ['access'], 'level': logging_level, 'propagate': False},
-    },
-}
+    }
+    chronos_handlers = ['default']
+    uvicorn_handlers = ['default']
+    if settings.logfire_token:
+        handlers['logfire'] = {'class': 'logfire.LogfireLoggingHandler'}
+        chronos_handlers.append('logfire')
+        uvicorn_handlers.append('logfire')
+
+    return {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'default': {
+                'defaults': 'uvicorn.logging.DefaultFormatter',
+                'fmt': '%(levelprefix)s %(message)s',
+                'use_colors': None,
+            },
+            'access': {
+                'defaults': 'uvicorn.logging.AccessFormatter',
+                'fmt': "%(levelprefix)s %(client_addr)s - '%(request_line)s' %(status_code)s",  # noqa: E501
+            },
+        },
+        'handlers': handlers,
+        'loggers': {
+            'chronos': {'handlers': chronos_handlers, 'level': logging_level, 'propagate': False},
+            'uvicorn': {'handlers': uvicorn_handlers, 'level': logging_level, 'propagate': False},
+            'uvicorn.error': {'level': logging_level},
+            'uvicorn.access': {'handlers': ['access'], 'level': logging_level, 'propagate': False},
+        },
+    }
+
+
+def setup_logging():
+    logging.config.dictConfig(_logging_dict_config())

--- a/chronos/main.py
+++ b/chronos/main.py
@@ -1,20 +1,19 @@
-import logging.config
+import logging
 import os
 
-import sentry_sdk
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
-from chronos.logging import config
+from chronos.logging import setup_logging
+from chronos.observability import init_sentry
 from chronos.utils import settings as _app_settings
-from chronos.views import main_router
-from chronos.worker import cronjob, lifespan
+
+init_sentry(for_celery_worker=False)
+
+from chronos.views import main_router  # noqa: E402
+from chronos.worker import cronjob, lifespan  # noqa: E402
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-if _app_settings.sentry_dsn:
-    sentry_sdk.init(
-        dsn=_app_settings.sentry_dsn,
-    )
 
 app = FastAPI(lifespan=lifespan)
 
@@ -34,7 +33,7 @@ if bool(_app_settings.logfire_token):
 
     instrument_web_app(app)
 
-logging.config.dictConfig(config)
+setup_logging()
 # Remove excessive sqlalchemy logging
 logging.getLogger('sqlalchemy').setLevel(logging.ERROR)
 logging.getLogger('sqlalchemy.engine.Engine').disabled = True

--- a/chronos/observability.py
+++ b/chronos/observability.py
@@ -1,8 +1,24 @@
+import logging
+
 import logfire
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from chronos.utils import settings
 
 _configured = False
+
+
+def init_sentry(*, for_celery_worker: bool = False):
+    if not settings.sentry_dsn:
+        return
+    integrations = [
+        LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
+    ]
+    if for_celery_worker:
+        integrations.append(CeleryIntegration())
+    sentry_sdk.init(dsn=settings.sentry_dsn, integrations=integrations)
 
 
 def configure_logfire():

--- a/chronos/utils.py
+++ b/chronos/utils.py
@@ -3,4 +3,4 @@ import logging
 from chronos.settings import Settings
 
 settings = Settings()
-app_logger = logging.getLogger('base')
+app_logger = logging.getLogger('chronos')

--- a/chronos/worker.py
+++ b/chronos/worker.py
@@ -68,13 +68,16 @@ def init_worker_process(**kwargs):
     This ensures each worker gets fresh connections instead of inheriting
     stale connections from the parent process, preventing SSL SYSCALL errors.
     """
-    app_logger.info('Disposing database engine pool for worker process')
-    engine.dispose()
+    from chronos.logging import setup_logging
+    from chronos.observability import init_sentry, instrument_worker
 
-    from chronos.observability import instrument_worker
-
+    init_sentry(for_celery_worker=True)
     if bool(settings.logfire_token):
         instrument_worker()
+    setup_logging()
+
+    app_logger.info('Disposing database engine pool for worker process')
+    engine.dispose()
 
 
 async def webhook_request(


### PR DESCRIPTION
## Summary

Addresses the gap noted on [PR #124](https://github.com/tutorcruncher/Chronos/pull/124#issuecomment-4160769538): standard library `logging` was not reaching the Logfire pipeline (especially Celery workers, which never import `main.py` and therefore never ran `dictConfig`).

## Changes

- **Logfire**: When `LOGFIRE_TOKEN` is set, add `logfire.LogfireLoggingHandler` to the `chronos` and `uvicorn` loggers alongside the existing stream handlers.
- **Logger name**: `app_logger` now uses `chronos` instead of `base`, so it is covered by the same dict config (and `chronos.dispatcher` still propagates to it).
- **Celery**: In `worker_process_init`, call `setup_logging()` after Sentry/Logfire setup so worker and dispatcher logs are configured in every forked worker process.
- **Sentry**: `init_sentry()` uses `LoggingIntegration` with `event_level=WARNING` so `logger.warning`, `logger.error`, and `logger.exception` produce Sentry events. Celery workers also get `CeleryIntegration` via `init_sentry(for_celery_worker=True)`.
- **Web**: `init_sentry` runs before importing `views`/`worker` so Sentry is ready before the app graph loads (Ruff `E402` noqa on those imports).

## Testing

- `uv run ruff check` on touched files.

Made with [Cursor](https://cursor.com)