### PR TITLE
Added deploy hook to gh workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,4 @@ jobs:
         run: |
           curl ${{ secrets.RENDER_DEPLOY_HOOK_URL_WEB }}
           curl ${{ secrets.RENDER_DEPLOY_HOOK_URL_WORKER }}
+          curl ${{ secrets.RENDER_DEPLOY_HOOK_URL_DISPATCHER }}


### PR DESCRIPTION
We were missing the deploy hook for render

Important Steps:
- [X] Get the dploy hook from Render and then set `RENDER_DEPLOY_HOOK_URL_DISPATCHER` in github settings > actions

<img width="794" height="410" alt="image" src="https://github.com/user-attachments/assets/5b6c5b42-c8a0-4332-9191-c81463ce5168" />
