### PR TITLE
Fix logs

### DIFF
--- a/chronos/main.py
+++ b/chronos/main.py
@@ -29,14 +29,14 @@ if _app_settings.dev_mode:
 app.add_middleware(CORSMiddleware, allow_origins=allowed_origins, allow_methods=['*'], allow_headers=['*'])
 
 
-if bool(_app_settings.logfire_token):
-    from chronos.observability import instrument_web_app
-
-    instrument_web_app(app)
-
 logging.config.dictConfig(config)
 # Remove excessive sqlalchemy logging
 logging.getLogger('sqlalchemy').setLevel(logging.ERROR)
 logging.getLogger('sqlalchemy.engine.Engine').disabled = True
+
+if bool(_app_settings.logfire_token):
+    from chronos.observability import instrument_web_app
+
+    instrument_web_app(app)
 app.include_router(main_router, prefix='')
 app.include_router(cronjob, prefix='')

--- a/chronos/observability.py
+++ b/chronos/observability.py
@@ -25,11 +25,20 @@ def configure_logfire():
 def _attach_logfire_handler():
     """Bridge Python stdlib logging to Logfire for the 'chronos' logger tree.
 
-    Sets an explicit level so Celery's --loglevel=error on the root logger
-    does not filter out INFO/WARNING records before they reach the handler.
+    Sets the logger level to INFO so Celery's --loglevel=error on the root
+    logger does not filter records before they reach any handler. To avoid
+    flooding stderr with INFO in production (where the StreamHandler from
+    dictConfig expects the level set by settings.log_level), the existing
+    stderr handlers are given an explicit level matching the configured one.
     """
     chronos_logger = logging.getLogger('chronos')
+    for h in chronos_logger.handlers:
+        if h.level == logging.NOTSET:
+            h.setLevel(settings.log_level.upper())
     chronos_logger.setLevel(logging.INFO)
+    # Guard against duplicate handlers: instrument_worker() and instrument_web_app()
+    # can both call this, and Celery's prefork pool may fire worker_process_init
+    # more than once in edge cases (e.g. pool restart).
     if not any(isinstance(h, LogfireLoggingHandler) for h in chronos_logger.handlers):
         chronos_logger.addHandler(LogfireLoggingHandler())
 

--- a/chronos/observability.py
+++ b/chronos/observability.py
@@ -26,19 +26,33 @@ def _attach_logfire_handler():
     """Bridge Python stdlib logging to Logfire for the 'chronos' logger tree.
 
     Sets the logger level to INFO so Celery's --loglevel=error on the root
-    logger does not filter records before they reach any handler. To avoid
-    flooding stderr with INFO in production (where the StreamHandler from
-    dictConfig expects the level set by settings.log_level), the existing
-    stderr handlers are given an explicit level matching the configured one.
+    logger does not filter records before they reach any handler.
+
+    In the web process, dictConfig has already installed a StreamHandler and
+    set propagate=False.  In worker processes dictConfig never runs, so
+    propagate defaults to True and there are no handlers — without the guard
+    below, every INFO record would propagate to Celery's root StreamHandler
+    (which has level=NOTSET) and flood production stderr.
     """
     chronos_logger = logging.getLogger('chronos')
-    for h in chronos_logger.handlers:
-        if h.level == logging.NOTSET:
-            h.setLevel(settings.log_level.upper())
+
+    if not chronos_logger.handlers:
+        # Worker process: add a stderr handler at the configured level so
+        # ERROR+ operational logs still appear on the console.
+        stderr_handler = logging.StreamHandler()
+        stderr_handler.setLevel(settings.log_level.upper())
+        chronos_logger.addHandler(stderr_handler)
+    else:
+        # Web process: dictConfig installed a StreamHandler with level=NOTSET.
+        # Pin it to the configured level so lowering the logger to INFO below
+        # doesn't flood stderr.
+        for h in chronos_logger.handlers:
+            if h.level == logging.NOTSET and not isinstance(h, LogfireLoggingHandler):
+                h.setLevel(settings.log_level.upper())
+
     chronos_logger.setLevel(logging.INFO)
-    # Guard against duplicate handlers: instrument_worker() and instrument_web_app()
-    # can both call this, and Celery's prefork pool may fire worker_process_init
-    # more than once in edge cases (e.g. pool restart).
+    chronos_logger.propagate = False
+
     if not any(isinstance(h, LogfireLoggingHandler) for h in chronos_logger.handlers):
         chronos_logger.addHandler(LogfireLoggingHandler())
 

--- a/chronos/observability.py
+++ b/chronos/observability.py
@@ -1,4 +1,7 @@
+import logging
+
 import logfire
+from logfire.integrations.logging import LogfireLoggingHandler
 
 from chronos.utils import settings
 
@@ -19,18 +22,30 @@ def configure_logfire():
     _configured = True
 
 
+def _attach_logfire_handler():
+    """Bridge Python stdlib logging to Logfire for the 'chronos' logger tree.
+
+    Sets an explicit level so Celery's --loglevel=error on the root logger
+    does not filter out INFO/WARNING records before they reach the handler.
+    """
+    chronos_logger = logging.getLogger('chronos')
+    chronos_logger.setLevel(logging.INFO)
+    if not any(isinstance(h, LogfireLoggingHandler) for h in chronos_logger.handlers):
+        chronos_logger.addHandler(LogfireLoggingHandler())
+
+
 def instrument_worker():
     configure_logfire()
+    _attach_logfire_handler()
     logfire.instrument_celery()
-    logfire.instrument_pydantic(record=settings.logfire_log_level)
+    logfire.instrument_httpx()
     logfire.instrument_psycopg()
-    logfire.instrument_requests()
 
 
 def instrument_web_app(app):
     configure_logfire()
+    _attach_logfire_handler()
     logfire.instrument_fastapi(app)
     logfire.instrument_celery()
-    logfire.instrument_pydantic(record=settings.logfire_log_level)
+    logfire.instrument_httpx()
     logfire.instrument_psycopg()
-    logfire.instrument_requests()

--- a/chronos/utils.py
+++ b/chronos/utils.py
@@ -3,4 +3,4 @@ import logging
 from chronos.settings import Settings
 
 settings = Settings()
-app_logger = logging.getLogger('base')
+app_logger = logging.getLogger('chronos')

--- a/chronos/worker.py
+++ b/chronos/worker.py
@@ -69,13 +69,14 @@ def init_worker_process(**kwargs):
     This ensures each worker gets fresh connections instead of inheriting
     stale connections from the parent process, preventing SSL SYSCALL errors.
     """
-    app_logger.info('Disposing database engine pool for worker process')
     engine.dispose()
 
     from chronos.observability import instrument_worker
 
     if bool(settings.logfire_token):
         instrument_worker()
+
+    app_logger.info('Worker process initialised, database engine pool disposed')
 
 
 async def webhook_request(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "fastapi==0.135.1",
     "fastapi_utilities==0.3.1",
     "httpx==0.28.1",
-    "logfire[fastapi,requests,psycopg2,celery]==4.29.0",
+    "logfire[fastapi,httpx,psycopg2,celery]==4.29.0",
     "pillow==12.1.1",
     "psycopg2-binary==2.9.11",
     "pydantic==2.12.5",
@@ -66,3 +66,4 @@ dev = [
 
 [tool.logfire]
     ignore_no_config = true
+    pydantic_plugin_record = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,4 @@ dev = [
 
 [tool.logfire]
     ignore_no_config = true
-    pydantic_plugin_record = "all"
+    pydantic_plugin_record = "failure"

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastapi-utilities" },
     { name = "httpx" },
-    { name = "logfire", extra = ["celery", "fastapi", "psycopg2", "requests"] },
+    { name = "logfire", extra = ["celery", "fastapi", "httpx", "psycopg2"] },
     { name = "pillow" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -274,7 +274,7 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.135.1" },
     { name = "fastapi-utilities", specifier = "==0.3.1" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "logfire", extras = ["fastapi", "requests", "psycopg2", "celery"], specifier = "==4.29.0" },
+    { name = "logfire", extras = ["fastapi", "httpx", "psycopg2", "celery"], specifier = "==4.29.0" },
     { name = "pillow", specifier = "==12.1.1" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
     { name = "pydantic", specifier = "==2.12.5" },
@@ -710,12 +710,12 @@ celery = [
 fastapi = [
     { name = "opentelemetry-instrumentation-fastapi" },
 ]
+httpx = [
+    { name = "opentelemetry-instrumentation-httpx" },
+]
 psycopg2 = [
     { name = "opentelemetry-instrumentation-psycopg2" },
     { name = "packaging" },
-]
-requests = [
-    { name = "opentelemetry-instrumentation-requests" },
 ]
 
 [[package]]
@@ -859,6 +859,22 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-psycopg2"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
@@ -870,21 +886,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/f2/e914cf7f3dd5fd84a2dd95be060ddd713791447216a8b99f036ad30c49b2/opentelemetry_instrumentation_psycopg2-0.60b1.tar.gz", hash = "sha256:46f46c47e11bf59b9746f35761995e4513fb985bab08d4e1f876a2c46ed4eeec", size = 11263, upload-time = "2025-12-11T13:37:07.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/02/e30d5aae987c99ad4a4b4f98e009bf7c4f010d888da641efb0428814a4a6/opentelemetry_instrumentation_psycopg2-0.60b1-py3-none-any.whl", hash = "sha256:f3841fe83400ee33c51ba5c38f4034534c3415075a4ebf01b97e49f8e0e5dd3e", size = 11283, upload-time = "2025-12-11T13:36:13.623Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-requests"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/4a/bb9d47d7424fc33aeba75275256ae6e6031f44b6a9a3f778d611c0c3ac27/opentelemetry_instrumentation_requests-0.60b1.tar.gz", hash = "sha256:9a1063c16c44a3ba6e81870c4fa42a0fac3ecef5a4d60a11d0976eec9046f3d4", size = 16366, upload-time = "2025-12-11T13:37:12.456Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/7f/969b59a5acccb4c35317421843d63d7853ad7a18078ca3a9b80c248be448/opentelemetry_instrumentation_requests-0.60b1-py3-none-any.whl", hash = "sha256:eec9fac3fab84737f663a2e08b12cb095b4bd67643b24587a8ecfa3cf4d0ca4c", size = 13141, upload-time = "2025-12-11T13:36:23.696Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes a set of observability gaps where Python `logging` calls (`app_logger.info(...)`, `app_logger.error(...)`, etc.) were completely invisible in Logfire. Over 7 days of production data, Logfire showed 5M span records but **zero log records, zero errors, and zero warnings** — despite the code having 30+ logging calls for webhook timeouts, delivery failures, auto-disable events, and dispatcher errors.

### Root causes found and fixed

1. **No logging bridge** — Logfire spans (`logfire.span()`) go through the OTel trace pipeline. Python `logging` calls go through a completely separate pipeline. There was no `LogfireLoggingHandler` to bridge them. Added one to the `chronos` logger in both web and worker processes.

2. **Logger name mismatch** — `app_logger` used `logging.getLogger("base")`, but the logging config only defines a `chronos` logger. The `base` logger sat outside the configured hierarchy with no handlers or explicit level. Renamed to `chronos` so it joins `dispatch_logger` (`chronos.dispatcher`) in the same tree.

3. **Celery root-level filtering** — Production workers run with `--loglevel=error`, which sets the Python root logger to ERROR. Since `base` had no explicit level, it inherited ERROR from root, silently dropping all INFO/WARNING records before they reached any handler. The fix sets an explicit `setLevel(INFO)` on the `chronos` logger so it is independent of Celery root level.

4. **Wrong HTTP library instrumented** — `logfire.instrument_requests()` was called, but the codebase uses `httpx` exclusively (never imports `requests`). All 360K+ daily webhook HTTP spans had `http_response_status_code = null`. Switched to `logfire.instrument_httpx()`.

5. **Pydantic instrumentation timing** — `instrument_pydantic()` was called after all models were already compiled, producing zero records. Moved to `pydantic_plugin_record = "failure"` in `pyproject.toml` which takes effect at import time. Set to `"failure"` (not `"all"`) to avoid noisy "validate_python succeeded" logs flooding Logfire on every request.

6. **Worker stderr propagation leak** — Setting the `chronos` logger to INFO without `propagate=False` would cause every INFO record to propagate to Celery's root StreamHandler (which has `level=NOTSET`), flooding production stderr. Fixed by setting `propagate=False` and adding an explicit stderr handler at the configured log level for worker processes (where `dictConfig` never runs).

7. **Startup log before instrumentation** — `app_logger.info('Disposing...')` ran before `instrument_worker()`, so it never reached Logfire. Moved the log after instrumentation.

### Changes

- **`chronos/utils.py`** — `getLogger("base")` -> `getLogger("chronos")`
- **`chronos/observability.py`** — Added `LogfireLoggingHandler` bridge; `instrument_requests()` -> `instrument_httpx()`; removed `instrument_pydantic()` (now in pyproject.toml); set `propagate=False` with explicit stderr handler for worker processes
- **`chronos/main.py`** — Moved `dictConfig` before `instrument_web_app()` so the handler is not wiped
- **`chronos/worker.py`** — Moved startup log after `instrument_worker()` so it reaches Logfire
- **`pyproject.toml`** — Logfire extra `requests` -> `httpx`; added `pydantic_plugin_record = "failure"`
- Deleted unused `chronos/scripts/leak_load_driver.py` (localhost-only load test script from the memory leak investigation, no longer needed)

## Test plan

- [x] All 105 tests pass
- [x] Lint clean
- [ ] After deploy, verify in Logfire: `SELECT kind, count(*) FROM records WHERE start_timestamp >= now() - interval '1 hour' GROUP BY kind` should show both span and log kinds
- [ ] Verify webhook spans now have HTTP status codes